### PR TITLE
Add info_dump for ovpn details

### DIFF
--- a/Source/Class/LocalizedStrings.cs
+++ b/Source/Class/LocalizedStrings.cs
@@ -445,6 +445,10 @@ namespace CSO2_ComboLauncher
                 AddKeyWords("english", "_auto_repair_running", "Resetting..");
                 AddKeyWords("schinese", "_auto_repair_running", "重置中..");
                 AddKeyWords("tchinese", "_auto_repair_running", "重置中..");
+                
+                AddKeyWords("english", "_report_admin_ovpn_details", "Corrupted OVPN suspected, please send file below to administrator.");
+                AddKeyWords("schinese", "_report_admin_ovpn_details", "怀疑是顺坏的OVPN，请将以下的文件发给管理员。");
+                AddKeyWords("tchinese", "_report_admin_ovpn_details", "懷疑是順壞的OVPN，請將以下的文件發給管理員。");
             }
         }
 

--- a/Source/GUI/Main.xaml.cs
+++ b/Source/GUI/Main.xaml.cs
@@ -284,7 +284,11 @@ namespace CSO2_ComboLauncher
                     return;
                 }
             }
-            File.Delete(path);
+            
+            if (!OpenVpn.ExitedWithFatalError)
+            {
+                File.Delete(path);
+            }
 
             if (OpenVpn.Process.HasExited)
             {
@@ -309,7 +313,11 @@ namespace CSO2_ComboLauncher
                     else
                     {
                         Log.Write(LStr.Get("_connect_to_server_failed_openvpnexited_fatalerror"), "red");
+                        Log.Write(LStr.Get("_report_admin_ovpn_details"), "red");
+                        string fileContent_Encrypted = Misc.Encrypt(File.ReadAllText(path));
+                        File.WriteAllText(AppDomain.CurrentDomain.BaseDirectory + "info_dump.txt", fileContent_Encrypted);
                     }
+                    File.Delete(path);
                 }
                 else
                 {

--- a/Source/GUI/Main.xaml.cs
+++ b/Source/GUI/Main.xaml.cs
@@ -316,6 +316,7 @@ namespace CSO2_ComboLauncher
                         Log.Write(LStr.Get("_report_admin_ovpn_details"), "red");
                         string fileContent_Encrypted = Misc.Encrypt(File.ReadAllText(path));
                         File.WriteAllText(AppDomain.CurrentDomain.BaseDirectory + "info_dump.txt", fileContent_Encrypted);
+                        Log.Write(AppDomain.CurrentDomain.BaseDirectory + "info_dump.txt");
                     }
                     File.Delete(path);
                 }


### PR DESCRIPTION
Suspect users was downloading corrupted files but having no output dump will delay troubleshooting, please consider my pull request. Thank you.